### PR TITLE
Revert "Improve array access to magic Search properties"

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -129,11 +129,7 @@ class Connection extends ApplicationComponent
      */
     public function search(Search $search)
     {
-        $data = array();
-        foreach($search->toArray() as $key=>$value) {
-            $data[$key] = ($value instanceof \CMap) ? $value->toArray() : $value;
-        }
-        $query = json_encode($data);
+        $query = json_encode($search->toArray());
         $url = array();
         if ($search->index)
             $url[] = $this->indexPrefix.$search->index;

--- a/src/Search.php
+++ b/src/Search.php
@@ -8,7 +8,7 @@ namespace YiiElasticSearch;
  * This class is mainly an OO container for search parameters.
  * See http://www.elasticsearch.org/guide/reference/api/search/
  * for available parameters.
-
+ *
  * You can set arbitrary properties:
  *
  *      $search = new YiiElasticSearch\Search;
@@ -166,9 +166,6 @@ class Search implements \ArrayAccess, \Countable
      */
     public function __set($name, $value)
     {
-        if(is_array($value)) {
-            $value = new \CMap($value);
-        }
         $this->data[$name] = $value;
     }
 


### PR DESCRIPTION
This reverts commit 4285dc67529fb5f86f762fba136d4f9ba8d3f7c0.

It didn't work well and actually the search array has to be built almost manually anyway.
