### PR TITLE
Add check for existing targets in console command

### DIFF
--- a/src/ConsoleCommand.php
+++ b/src/ConsoleCommand.php
@@ -45,7 +45,7 @@ class ConsoleCommand extends CConsoleCommand
     public $verbose = false;
 
     /**
-     * @var bool wether to only perform the command if target does not exist. Default is false.
+     * @var bool whether to only perform the command if target does not exist. Default is false.
      */
     public $skipExisting = false;
 
@@ -384,7 +384,7 @@ EOD;
 
     /**
      * @param string $url to test for existance
-     * @return bool wether the given resource exists
+     * @return bool whether the given resource exists
      */
     protected function exists($url,$method='head')
     {

--- a/src/Document.php
+++ b/src/Document.php
@@ -152,7 +152,7 @@ class Document implements DocumentInterface, \ArrayAccess, \Countable, \Iterator
 
     /**
      * @param string $name the field name
-     * @return bool wether the document has a field with the given name
+     * @return bool whether the document has a field with the given name
      */
     public function __isset($name)
     {


### PR DESCRIPTION
@phpnode useful e.g. in puppet environments that require one-off creation of mappings or imports.
