### PR TITLE
Pagination getOffset error with $_GET parameter

### DIFF
--- a/src/DataProvider.php
+++ b/src/DataProvider.php
@@ -118,6 +118,7 @@ class DataProvider extends CDataProvider
         if($this->fetchedData===null) {
             $search = $this->_search;
             if (($pagination = $this->getPagination()) !== false) {
+                $pagination->validateCurrentPage = false;
                 $search['from'] = $pagination->getOffset();
                 $search['size'] = $pagination->pageSize;
             }


### PR DESCRIPTION
Set validateCurrentPage to false in order to work with page number from $_GET before runing elasticsearch query
