### PR TITLE
Fixing active record relation handling after populationg from search result

### DIFF
--- a/src/DataProvider.php
+++ b/src/DataProvider.php
@@ -130,6 +130,7 @@ class DataProvider extends CDataProvider
             $modelClass = get_class($this->model);
             foreach($this->resultSet->getResults() as $result) {
                 $model = new $modelClass;
+                $model->setIsNewRecord(false);
                 $model->parseElasticDocument($result);
                 $this->fetchedData[] = $model;
             }


### PR DESCRIPTION
`CActiveRecord::getRelated()` returns current relation data only if model is not new. https://github.com/yiisoft/yii/blob/master/framework/db/ar/CActiveRecord.php#L262
