### PR TITLE
console cmd index action - use global namespace for provider and iterato...

### DIFF
--- a/src/YiiElasticSearch/ConsoleCommand.php
+++ b/src/YiiElasticSearch/ConsoleCommand.php
@@ -151,8 +151,8 @@ EOD;
 
         $this->message("Adding $count '{$this->model}' records from table '$table' to index '$index'\n 0% ", false);
 
-        $provider = new CActiveDataProvider($model);
-        $iterator = new CDataProviderIterator($provider);
+        $provider = new \CActiveDataProvider($model);
+        $iterator = new \CDataProviderIterator($provider);
         foreach($iterator as $record) {
             $record->indexElasticDocument();
             $n++;


### PR DESCRIPTION
We should use global namespaces in the ConsoleCommand's index action otherwise we get a file missing php error:

```
0% PHP Error[2]: include([...]\common\lib\vendor\codemix\yiielasticsearch\src\YiiElasticSearch\CDataProviderIterator.php): failed to open stream: No such file or directory
    in file [...]\common\lib\vendor\yiisoft\yii\framework\YiiBase.php at line 433
```

It is connected to the Issue #23: Use iterator for index command
