### PR TITLE
Condition isset($msg->error) added

### DIFF
--- a/src/YiiElasticSearch/Connection.php
+++ b/src/YiiElasticSearch/Connection.php
@@ -173,7 +173,7 @@ class Connection extends ApplicationComponent
         }
         catch (\Guzzle\Http\Exception\BadResponseException $e) {
             $body = $e->getResponse()->getBody(true);
-            if(($msg = json_decode($body))!==null) {
+            if(($msg = json_decode($body))!==null && isset($msg->error)) {
                 throw new \CException($msg->error);
             } else {
                 throw new \CException($e);


### PR DESCRIPTION
Trying to fix php error "Undefined property: stdClass::$error" when there is json response but there is no "error" field.
This scenario happens when we're trying to delete a non-existent record (like when SearchableBehavior is added after document is created).

``` json
> http DELETE 'http://localhost:9200/mywebapplication/minute/1' 
HTTP/1.1 404 Not Found
Content-Length: 83
Content-Type: application/json; charset=UTF-8

{
    "_id": "1", 
    "_index": "mywebapplication", 
    "_type": "minute", 
    "_version": 2, 
    "found": false
}
```

It's better to ignore 404 errors when deleting but I'm not sure how to do this.
