### PR TITLE
Fixed console extra calculation count

### DIFF
--- a/src/YiiElasticSearch/ConsoleCommand.php
+++ b/src/YiiElasticSearch/ConsoleCommand.php
@@ -129,7 +129,9 @@ EOD;
 
         $model  = $this->getModel();
         $table  = $model->tableName();
-        $count  = $model->count();
+        $provider = new \CActiveDataProvider($model);
+        $count = $provider->totalItemCount;
+
         $step   = $count > 5 ? floor($count/5) : 1;
         $index  = Yii::app()->elasticSearch->indexPrefix.$model->elasticIndex;
         $type   = $model->elasticType;
@@ -151,7 +153,6 @@ EOD;
 
         $this->message("Adding $count '{$this->model}' records from table '$table' to index '$index'\n 0% ", false);
 
-        $provider = new \CActiveDataProvider($model);
         $iterator = new \CDataProviderIterator($provider);
         foreach($iterator as $record) {
             $record->indexElasticDocument();


### PR DESCRIPTION
We can get a total count of records from CDataProvider.

I have an issue with model scopes. I have extended ConsoleCommand and overloaded `getModel()` method to specify a scope for the model, but my scope was reset in the `count()` method (please see `applyScopes()`) and data provider uses a new instance of CDbCriteria without my scope.

So, I offer to use total count property `CDataProvider::totalItemCount`.