### PR TITLE
Fixed error messaging for a new format

### DIFF
--- a/src/YiiElasticSearch/Connection.php
+++ b/src/YiiElasticSearch/Connection.php
@@ -174,7 +174,7 @@ class Connection extends ApplicationComponent
         catch (\Guzzle\Http\Exception\BadResponseException $e) {
             $body = $e->getResponse()->getBody(true);
             if(($msg = json_decode($body))!==null && isset($msg->error)) {
-                throw new \CException($msg->error);
+                throw new \CException(is_object($msg->error) ? $msg->error->reason : $msg->error);
             } else {
                 throw new \CException($e);
             }

--- a/src/YiiElasticSearch/ConsoleCommand.php
+++ b/src/YiiElasticSearch/ConsoleCommand.php
@@ -355,8 +355,8 @@ EOD;
             $request->send();
         } catch (\Guzzle\Http\Exception\BadResponseException $e) {
             $body = $e->getResponse()->getBody(true);
-            if(($msg = json_decode($body))!==null) {
-                $this->message($msg->error);
+            if(($msg = json_decode($body))!==null && isset($msg->error)) {
+                $this->message(is_object($msg->error) ? $msg->error->reason : $msg->error);
             } else {
                 $this->message($e->getMessage());
             }


### PR DESCRIPTION
Error message format has been changed in a new ES version (since 2.x). Now It's an object.