### PR TITLE
Enhance creating mapping with additional options

### DIFF
--- a/src/YiiElasticSearch/ConsoleCommand.php
+++ b/src/YiiElasticSearch/ConsoleCommand.php
@@ -48,6 +48,10 @@ class ConsoleCommand extends CConsoleCommand
      * @var bool whether to only perform the command if target does not exist. Default is false.
      */
     public $skipExisting = false;
+    /**
+     * @var string addition options for a creating index
+     */
+    public $options = '{}';
 
     /**
      * @return string help for this command
@@ -196,9 +200,9 @@ EOD;
             $this->usageError("Invalid JSON in $map");
         }
 
-        $body = json_encode(array(
+        $body = json_encode(\CMap::mergeArray(array(
             'mappings' => $mapping,
-        ));
+        ), json_decode($this->options, true)));
 
         $this->performRequest($elastic->client->put($index, array("Content-type" => "application/json"))->setBody($body));
 


### PR DESCRIPTION
Currently no any ways to specify additional settings while the index/mapping is creating. For example, I need to have 3 shards. I can create an index with 3 shards, but after trying to apply a mapping my index will be recreated with default settings (5 shards). We can add ability to put additional settings somehing like that:

`./yiic elastic map --model=ModelName --map=mapping.json --options="{'settings': {'index' : {'number_of_shards': 3, 'number_of_replicas': 1}}}"`