### PR TITLE
Added support of a script fields

### DIFF
--- a/src/YiiElasticSearch/SearchResult.php
+++ b/src/YiiElasticSearch/SearchResult.php
@@ -22,6 +22,11 @@ class SearchResult extends Document
     protected $_score;
 
     /**
+     * @var array the script_fields
+     */
+    protected $_scriptFields;
+
+    /**
      * Initialize the search result
      * @param ResultSet $resultSet the result set this is a part of
      * @param array $result the result data
@@ -34,6 +39,7 @@ class SearchResult extends Document
         $this->_id = $result['_id'];
         $this->_score = $result['_score'];
         $this->_source = $result['_source'];
+        $this->_scriptFields = isset($result['fields']) ? $result['fields'] : [];
     }
 
     /**
@@ -50,5 +56,13 @@ class SearchResult extends Document
     public function getResultSet()
     {
         return $this->_resultSet;
+    }
+
+    /**
+     * @return array of the Script fields
+     */
+    public function getScriptFields()
+    {
+        return $this->_scriptFields;
     }
 }


### PR DESCRIPTION
Currently there is no capability to use [Script Fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html).
We can get it from elastic response and set it to SearchResults object.